### PR TITLE
New version v3: remove log library, modernize a bit

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,25 @@
+---
+env:
+  node: true
+  mocha: true
+  es6: true
+extends: eslint:recommended
+parserOptions:
+  sourceType: module
+  ecmaVersion: 8
+rules:
+  no-inner-declarations: 0
+  no-unused-vars:
+  - error
+  - args: after-used
+  no-console: 0
+  no-constant-condition: 0
+  indent:
+  - error
+  - tab
+  max-len:
+  - off
+  - tabWidth: 4
+  linebreak-style:
+  - error
+  - unix

--- a/index.js
+++ b/index.js
@@ -1,14 +1,11 @@
-'use strict';
-
 /**
  * Testing library.
  * (C) 2013 Alex Fernández.
  */
 
 
-// requires
-const runner = require('./lib/runner.js');
-const util = require('util');
+import {runAll} from './lib/runner.js'
+import util from 'util'
 
 const GREEN = '\u001b[32m';
 const RED = '\u001b[1;31m';
@@ -23,8 +20,7 @@ let errors = 0;
  *	The function must be in node.js style: callback(error, result).
  *	In this case, callback(null, message).
  */
-exports.success = function(message, callback)
-{
+export function success(message, callback) {
 	const parameters = processParameters(arguments);
 	message = parameters.message || true;
 	callback = parameters.callback;
@@ -41,7 +37,7 @@ exports.success = function(message, callback)
 	{
 		notice(message);
 	}
-};
+}
 
 /**
  * Reports a failure for the current test. Parameters:
@@ -50,8 +46,7 @@ exports.success = function(message, callback)
  *	The function must be in node.js style: callback(error, result).
  *	In this case, callback(message).
  */
-exports.failure = function(message, callback)
-{
+export function failure(message, callback) {
 	errors += 1;
 	const parameters = processParameters(arguments);
 	message = parameters.message || 'Failure';
@@ -61,8 +56,11 @@ exports.failure = function(message, callback)
 		return callback(message);
 	}
 	error(message);
-};
-exports.fail = exports.failure;
+}
+
+export function fail(...args) {
+	return failure(...args)
+}
 
 /**
  * Find a callback in any parameter, extract the message. Parameters:
@@ -97,18 +95,17 @@ function processParameters(args)
  */
 function testSuccessFailure(callback)
 {
-	exports.success('success');
-	exports.failure('test; please ignore');
+	success('success');
+	failure('test; please ignore');
 	// remove this error
 	errors -= 1;
-	exports.success('Success and failure work', callback);
+	success('Success and failure work', callback);
 }
 
 /**
  * Assert a condition, and show a failure otherwise.
  */
-exports.verify = function(condition, message, callback)
-{
+export function verify(condition, message, callback) {
 	if (condition)
 	{
 		return;
@@ -118,15 +115,16 @@ exports.verify = function(condition, message, callback)
 	message = parameters.message || 'Assertion error';
 	callback = parameters.callback;
 	// show failure with the given arguments
-	exports.failure(message, callback);
-};
-exports.assert = exports.verify;
+	failure(message, callback);
+}
+export function assert(condition, message, callback) {
+	return verify(condition, message, callback)
+}
 
 /**
  * Assert that two values are equal, and show a failure otherwise.
  */
-exports.equals = function(actual, expected, message, callback)
-{
+export function equals(actual, expected, message, callback) {
 	if (actual == expected)
 	{
 		return;
@@ -142,15 +140,17 @@ exports.equals = function(actual, expected, message, callback)
 	message = parameters.message || 'Assertion for equality error';
 	message = util.format('%s: expected %s but got %s', message, util.inspect(expected), util.inspect(actual));
 	callback = parameters.callback;
-	exports.failure(message, callback);
-};
-exports.assertEquals = exports.equals;
+	failure(message, callback);
+}
+
+export function assertEquals(...args) {
+	return equals(...args);
+}
 
 /**
  * Assert that two values are *not* equal, and show a failure otherwise.
  */
-exports.notEquals = function(actual, unexpected, message, callback)
-{
+export function notEquals(actual, unexpected, message, callback) {
 	if (actual != unexpected)
 	{
 		if (JSON.stringify(actual) != JSON.stringify(unexpected))
@@ -165,12 +165,14 @@ exports.notEquals = function(actual, unexpected, message, callback)
 	message = parameters.message || 'Assertion for inequality error';
 	message = util.format('%s: expected %s different from %s', message, util.inspect(actual), util.inspect(unexpected));
 	callback = parameters.callback;
-	exports.failure(message, callback);
-};
-exports.assertNotEquals = exports.notEquals;
+	failure(message, callback);
+}
 
-exports.contains = function(container, piece, message, callback)
-{
+export function assertNotEquals(...args) {
+	return notEquals(...args);
+}
+
+export function contains(container, piece, message, callback) {
 	if (typeof container == 'string')
 	{
 		if (container.indexOf(piece) != -1)
@@ -191,21 +193,20 @@ exports.contains = function(container, piece, message, callback)
 	else
 	{
 		message = 'Invalid container ' + typeof container + ', should be string or array, cannot check ' + message;
-		return exports.failure(message, callback);
+		return failure(message, callback);
 	}
 	delete arguments[0];
 	delete arguments[1];
 	const parameters = processParameters(arguments);
 	message = parameters.message || 'Assertion for equality error';
 	message = util.format('%s: %s does not contain %s', message, util.inspect(container), util.inspect(piece));
-	exports.failure(message, parameters.callback);
-};
+	failure(message, parameters.callback);
+}
 
 /**
  * Check that the error is falsy, show a failure otherwise.
  */
-exports.check = function(error, message, callback)
-{
+export function check(error, message, callback) {
 	if (!error)
 	{
 		return;
@@ -220,21 +221,21 @@ exports.check = function(error, message, callback)
 	message = parameters.message + ': ' + description;
 	callback = parameters.callback;
 	// show failure with the given arguments
-	exports.failure(message, callback);
-};
+	failure(message, callback);
+}
 
 /**
  * Test assert functions.
  */
 function testAssert(callback)
 {
-	exports.verify(1 + 1 == 2, 'Basic assert', callback);
-	exports.equals(1 + 1, 2, 'Basic assert equals', callback);
-	exports.equals({a: 'a'}, {a: 'a'}, 'Object assert equals', callback);
-	exports.notEquals(1 + 1, 3, 'Basic assert not equals', callback);
-	exports.notEquals({a: 'a'}, {a: 'b'}, 'Object assert not equals', callback);
-	exports.check(false, 'Check should not trigger', callback);
-	exports.success(callback);
+	verify(1 + 1 == 2, 'Basic assert', callback);
+	equals(1 + 1, 2, 'Basic assert equals', callback);
+	equals({a: 'a'}, {a: 'a'}, 'Object assert equals', callback);
+	notEquals(1 + 1, 3, 'Basic assert not equals', callback);
+	notEquals({a: 'a'}, {a: 'b'}, 'Object assert not equals', callback);
+	check(false, 'Check should not trigger', callback);
+	success(callback);
 }
 
 /**
@@ -244,8 +245,7 @@ function testAssert(callback)
  *	- timeout: an optional timeout to consider tests as failed.
  *	- callback: an optional function to call after tests have finished.
  */
-exports.run = function(tests, timeout, callback)
-{
+export function run(tests, timeout, callback) {
 	if (typeof timeout == 'function')
 	{
 		callback = timeout;
@@ -280,7 +280,7 @@ exports.run = function(tests, timeout, callback)
 		}
 	}, timeout);
 	// run the tests
-	runner.run(tests, function(error, result)
+	runAll(tests, function(error, result)
 	{
 		clearTimeout(running);
 		if (callback)
@@ -288,26 +288,24 @@ exports.run = function(tests, timeout, callback)
 			return callback(error, result);
 		}
 	});
-};
+}
 
 /**
  * Show the result of some tests. Parameters:
  *	- error: when tests have failed, an error message.
  *	- result: when tests have succeeded, the whole results.
  */
-exports.show = function(error, result)
-{
+export function show(error, result) {
 	showResults(error, result);
-};
+}
 
 /**
  * Show the complete hierarchical error results.
  */
-exports.showComplete = function(error, result)
-{
+export function showComplete(error, result) {
 	console.log('Complete test results: %s', result);
 	showResults(error, result);
-};
+}
 
 /**
  * Show test results.
@@ -346,7 +344,7 @@ function testObject(callback)
 			key: 'value',
 		},
 	};
-	exports.success(object, callback);
+	success(object, callback);
 }
 
 /**
@@ -354,15 +352,14 @@ function testObject(callback)
  */
 function testSingleFunction(callback)
 {
-	exports.success(true, callback);
+	success(true, callback);
 }
 
 /**
  * Pass a tester callback whose results you want shown.
  * Returns a function that runs the tests, shows the results and invokes the callback.
  */
-exports.toShow = function(tester)
-{
+export function toShow(tester) {
 	return function(callback)
 	{
 		tester(function(error, result)
@@ -371,7 +368,7 @@ exports.toShow = function(tester)
 			callback(error, result);
 		});
 	};
-};
+}
 
 async function testPromise()
 {
@@ -390,8 +387,7 @@ function sleep(ms) {
 /**
  * Run all module tests.
  */
-exports.test = function(callback)
-{
+export function test(callback) {
 	const tests = [
 		testSuccessFailure,
 		testAssert,
@@ -402,13 +398,13 @@ exports.test = function(callback)
 		},
 		testPromise,
 	];
-	exports.run(testSingleFunction, function(error, result)
+	run(testSingleFunction, function(error, result)
 	{
-		exports.check(error, 'Could not run single function', callback);
-		exports.assert(result, 'Invalid test result', callback);
-		exports.run(tests, callback);
+		check(error, 'Could not run single function', callback);
+		assert(result, 'Invalid test result', callback);
+		run(tests, callback);
 	});
-};
+}
 
 function error(message) {
 	console.error(RED + message + BLACK);
@@ -416,11 +412,5 @@ function error(message) {
 
 function notice(message) {
 	console.log(GREEN + message + BLACK);
-}
-
-// run tests if invoked directly
-if (__filename == process.argv[1])
-{
-	exports.test(exports.show);
 }
 

--- a/index.js
+++ b/index.js
@@ -7,17 +7,16 @@
 
 
 // requires
-var Log = require('log');
 var runner = require('./lib/runner.js');
 var util = require('util');
 
 // globals
-var log = new Log('info');
 var errors = 0;
 
 // constants
-var IN_GREEN = '\u001b[32m%s\u001b[0m';
-var IN_RED = '\u001b[1;31m%s\u001b[0m';
+var GREEN = '\u001b[32m';
+var RED = '\u001b[1;31m';
+var BLACK = '\u001b[0m';
 
 
 /**
@@ -39,11 +38,11 @@ exports.success = function(message, callback)
 	if (errors)
 	{
 		// previous errors detected
-		log.notice(IN_RED, 'With errors: ' + message);
+		error('With errors: ' + message);
 	}
 	else
 	{
-		log.notice(IN_GREEN, message);
+		notice(message);
 	}
 };
 
@@ -64,7 +63,7 @@ exports.failure = function(message, callback)
 	{
 		return callback(message);
 	}
-	log.error(IN_RED, message);
+	error(message);
 };
 exports.fail = exports.failure;
 
@@ -257,7 +256,7 @@ exports.run = function(tests, timeout, callback)
 	}
 	if (!callback)
 	{
-		log.warning('No callback given to testing.run()');
+		console.log('No callback given to testing.run()');
 	}
 	if (typeof tests == 'function')
 	{
@@ -277,7 +276,7 @@ exports.run = function(tests, timeout, callback)
 	var running = setTimeout(function()
 	{
 		var message = 'Package tests did not call back';
-		log.error(IN_RED, message);
+		error(message);
 		if (callback)
 		{
 			return callback(message);
@@ -309,7 +308,7 @@ exports.show = function(error, result)
  */
 exports.showComplete = function(error, result)
 {
-	log.notice('Complete test results: %s', result);
+	console.log('Complete test results: %s', result);
 	showResults(error, result);
 };
 
@@ -333,7 +332,7 @@ function showResults(error, result)
 	{
 		printable = result.getSummary();
 	}
-	log.notice('All tests run with %s', printable);
+	console.log('All tests run with %s', printable);
 	if (result.failure)
 	{
 		process.exit(1);
@@ -413,6 +412,14 @@ exports.test = function(callback)
 		exports.run(tests, callback);
 	});
 };
+
+function error(message) {
+	console.error(RED + message + BLACK);
+}
+
+function notice(message) {
+	console.log(GREEN + message + BLACK);
+}
 
 // run tests if invoked directly
 if (__filename == process.argv[1])

--- a/index.js
+++ b/index.js
@@ -265,7 +265,7 @@ exports.run = function(tests, timeout, callback)
 	var nTests = 0;
 	for (var key in tests)
 	{
-		if (tests.hasOwnProperty(key))
+		if (Object.hasOwn(tests, key))
 		{
 			nTests += 1;
 		}

--- a/index.js
+++ b/index.js
@@ -7,16 +7,13 @@
 
 
 // requires
-var runner = require('./lib/runner.js');
-var util = require('util');
+const runner = require('./lib/runner.js');
+const util = require('util');
 
-// globals
-var errors = 0;
-
-// constants
-var GREEN = '\u001b[32m';
-var RED = '\u001b[1;31m';
-var BLACK = '\u001b[0m';
+const GREEN = '\u001b[32m';
+const RED = '\u001b[1;31m';
+const BLACK = '\u001b[0m';
+let errors = 0;
 
 
 /**
@@ -28,7 +25,7 @@ var BLACK = '\u001b[0m';
  */
 exports.success = function(message, callback)
 {
-	var parameters = processParameters(arguments);
+	const parameters = processParameters(arguments);
 	message = parameters.message || true;
 	callback = parameters.callback;
 	if (callback)
@@ -56,7 +53,7 @@ exports.success = function(message, callback)
 exports.failure = function(message, callback)
 {
 	errors += 1;
-	var parameters = processParameters(arguments);
+	const parameters = processParameters(arguments);
 	message = parameters.message || 'Failure';
 	callback = parameters.callback;
 	if (callback)
@@ -73,15 +70,15 @@ exports.fail = exports.failure;
  */
 function processParameters(args)
 {
-	var parameters = {};
+	const parameters = {};
 	if (!arguments[0])
 	{
 		return parameters;
 	}
-	var reargs = [];
-	for (var i in args)
+	const reargs = [];
+	for (const i in args)
 	{
-		var arg = args[i];
+		const arg = args[i];
 		if (typeof arg == 'function')
 		{
 			parameters.callback = arg;
@@ -117,7 +114,7 @@ exports.verify = function(condition, message, callback)
 		return;
 	}
 	delete arguments[0];
-	var parameters = processParameters(arguments);
+	const parameters = processParameters(arguments);
 	message = parameters.message || 'Assertion error';
 	callback = parameters.callback;
 	// show failure with the given arguments
@@ -141,7 +138,7 @@ exports.equals = function(actual, expected, message, callback)
 	}
 	delete arguments[0];
 	delete arguments[1];
-	var parameters = processParameters(arguments);
+	const parameters = processParameters(arguments);
 	message = parameters.message || 'Assertion for equality error';
 	message = util.format('%s: expected %s but got %s', message, util.inspect(expected), util.inspect(actual));
 	callback = parameters.callback;
@@ -164,7 +161,7 @@ exports.notEquals = function(actual, unexpected, message, callback)
 	}
 	delete arguments[0];
 	delete arguments[1];
-	var parameters = processParameters(arguments);
+	const parameters = processParameters(arguments);
 	message = parameters.message || 'Assertion for inequality error';
 	message = util.format('%s: expected %s different from %s', message, util.inspect(actual), util.inspect(unexpected));
 	callback = parameters.callback;
@@ -183,7 +180,7 @@ exports.contains = function(container, piece, message, callback)
 	}
 	else if (Array.isArray(container))
 	{
-		for (var i = 0; i < container.length; i++)
+		for (let i = 0; i < container.length; i++)
 		{
 			if (container[i] == piece)
 			{
@@ -198,7 +195,7 @@ exports.contains = function(container, piece, message, callback)
 	}
 	delete arguments[0];
 	delete arguments[1];
-	var parameters = processParameters(arguments);
+	const parameters = processParameters(arguments);
 	message = parameters.message || 'Assertion for equality error';
 	message = util.format('%s: %s does not contain %s', message, util.inspect(container), util.inspect(piece));
 	exports.failure(message, parameters.callback);
@@ -214,8 +211,8 @@ exports.check = function(error, message, callback)
 		return;
 	}
 	delete arguments[0];
-	var parameters = processParameters(arguments);
-	var description = util.inspect(error);
+	const parameters = processParameters(arguments);
+	let description = util.inspect(error);
 	if (error.stack)
 	{
 		description = error.stack;
@@ -262,8 +259,8 @@ exports.run = function(tests, timeout, callback)
 	{
 		tests = [tests];
 	}
-	var nTests = 0;
-	for (var key in tests)
+	let nTests = 0;
+	for (const key in tests)
 	{
 		if (Object.hasOwn(tests, key))
 		{
@@ -273,9 +270,9 @@ exports.run = function(tests, timeout, callback)
 	// if no timeout, give each test one second
 	timeout = timeout || 1000 * nTests;
 	// start the timer
-	var running = setTimeout(function()
+	const running = setTimeout(function()
 	{
-		var message = 'Package tests did not call back';
+		const message = 'Package tests did not call back';
 		error(message);
 		if (callback)
 		{
@@ -323,7 +320,7 @@ function showResults(error, result)
 		process.exit(1);
 		return;
 	}
-	var printable = 'No test result';
+	let printable = 'No test result';
 	if (typeof result == 'string')
 	{
 		printable = result;
@@ -344,7 +341,7 @@ function showResults(error, result)
  */
 function testObject(callback)
 {
-	var object = {
+	const object = {
 		embedded: {
 			key: 'value',
 		},
@@ -395,7 +392,7 @@ function sleep(ms) {
  */
 exports.test = function(callback)
 {
-	var tests = [
+	const tests = [
 		testSuccessFailure,
 		testAssert,
 		{

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -6,11 +6,6 @@
  */
 
 
-// requires
-var Log = require('log');
-
-// globals
-var log = new Log('info');
 var next;
 
 
@@ -243,7 +238,7 @@ function uncaughtException(error)
 {
 	if (!next)
 	{
-		return log.error('Exception without next text');
+		return console.error('Exception without next text');
 	}
 	next('Uncaught exception: ' + error.stack);
 }
@@ -307,7 +302,7 @@ var Runner = function(name, series)
 				{
 					if (error)
 					{
-						log.error('Could not run all functions');
+						console.error('Could not run all functions');
 						return;
 					}
 					self.result.add(runner.result);
@@ -336,7 +331,7 @@ var Runner = function(name, series)
 				var testFunction = getFileTest(value);
 				if (!testFunction)
 				{
-					log.error('Cannot get test function from file %s', value);
+					console.error('Cannot get test function from file %s', value);
 					return deleteAndRunNext(key, callback);
 				}
 				next = getNext(key, value, callback);
@@ -344,12 +339,11 @@ var Runner = function(name, series)
 			}
 			else
 			{
-				log.error('Key %s has an invalid value %s', key, value);
+				console.error('Key %s has an invalid value %s', key, value);
 				return deleteAndRunNext(key, callback);
 			}
 			// only the first element in the series is used;
 			// the rest are called by recursion in deleteAndRunNext()
-			return;
 		}
 	}
 
@@ -365,7 +359,7 @@ var Runner = function(name, series)
 		}
 		catch(exception)
 		{
-			log.error('File %s not found: %s', filename, exception);
+			console.error('File %s not found: %s', filename, exception);
 		}
 	}
 
@@ -456,7 +450,7 @@ function testRun()
 		console.assert(result.results.g.results.two, 'Should have result for two');
 		console.assert(result.results.g.results.two.success, 'Should have success for two');
 		console.assert(result.results.g.results.two.message == 'g1', 'Should have g1 for two');
-		log.info('Test run successful with 2 failures: %s', result);
+		console.log('Test run successful with 2 failures: %s', result);
 	});
 }
 
@@ -467,7 +461,7 @@ function clone(series)
 {
 	if (typeof series != 'object')
 	{
-		log.error('Invalid series %s', JSON.stringify(series));
+		console.error('Invalid series %s', JSON.stringify(series));
 		return;
 	}
 	var copy = {};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -6,164 +6,150 @@
  */
 
 
-var next;
-
-
-// constants
-var GREEN = '\u001b[32m';
-var RED = '\u001b[1;31m';
-var PURPLE = '\u001b[1;35m';
-var BLACK = '\u001b[0m';
-var SUCCESS_START = GREEN + '✓ ';
-var END = BLACK;
-var FAILURE_START = RED + '✕ ';
-var UNKNOWN_START = PURPLE + '? ';
-var INVALID_START = PURPLE + '??? ';
-var SEPARATOR = ': ';
+const GREEN = '\u001b[32m';
+const RED = '\u001b[1;31m';
+const PURPLE = '\u001b[1;35m';
+const BLACK = '\u001b[0m';
+const SUCCESS_START = GREEN + '✓ ';
+const END = BLACK;
+const FAILURE_START = RED + '✕ ';
+const UNKNOWN_START = PURPLE + '? ';
+const INVALID_START = PURPLE + '??? ';
+const SEPARATOR = ': ';
+let next = null;
 
 
 /**
  * A test result.
  */
-var TestResult = function(key)
-{
-	// self-reference
-	var self = this;
-
-	// attributes
-	self.key = key;
-	self.success = false;
-	self.failure = false;
-	self.message = null;
-	var finished = false;
+class TestResult {
+	constructor(key) {
+		this.key = key;
+		this.success = false;
+		this.failure = false;
+		this.message = null;
+		this.finished = false;
+	}
 	
 	/**
 	 * Callback for the test result.
 	 * Can only be called once.
 	 */
-	self.callback = function(error, result)
-	{
+	callback(error, result) {
 		if (error)
 		{
 			// only report the first failure
-			if (!self.failure)
+			if (!this.failure)
 			{
-				fail(error);
+				this.fail(error);
 			}
 		}
-		else if (!self.failure)
+		else if (!this.failure)
 		{
 			if (result && result.failure)
 			{
-				return fail(result);
+				return this.fail(result);
 			}
-			return succeed(result);
+			return this.succeed(result);
 		}
-	};
+	}
 
 	/**
 	 * Report a failure.
 	 */
-	function fail(message)
+	fail(message)
 	{
-		self.failure = true;
-		self.success = false;
-		self.message = message;
-		console.log(FAILURE_START + self.key + SEPARATOR + message + END);
-		finished = true;
+		this.failure = true;
+		this.success = false;
+		this.message = message;
+		console.log(FAILURE_START + this.key + SEPARATOR + message + END);
+		this.finished = true;
 	}
 
 	/**
 	 * Report a success.
 	 */
-	function succeed(message)
+	succeed(message)
 	{
-		if (finished)
+		if (this.finished)
 		{
-			if (self.success)
+			if (this.success)
 			{
 				message = 'Duplicated call to callback';
 			}
 			// only one success allowed
-			return fail(message);
+			return this.fail(message);
 		}
-		self.success = true;
-		self.message = message;
-		console.log(SUCCESS_START + self.key + SEPARATOR + message + END);
-		finished = true;
+		this.success = true;
+		this.message = message;
+		console.log(SUCCESS_START + this.key + SEPARATOR + message + END);
+		this.finished = true;
 	}
 
 	/**
 	 * Return a printable representation.
 	 */
-	self.toString = function(indent)
-	{
-		var message = self.key;
-		if (self.message)
+	toString(indent) {
+		let message = this.key;
+		if (this.message)
 		{
-			message += SEPARATOR + self.message;
+			message += SEPARATOR + this.message;
 		}
-		return getPrintable(self, message, indent);
-	};
-};
+		return getPrintable(this, message, indent);
+	}
+}
 
 /**
  * A result that contains other results.
  */
-var CompositeResult = function(key)
-{
-	// self-reference
-	var self = this;
-
-	// attributes
-	self.key = key;
-	self.success = false;
-	self.failure = false;
-	self.failures = 0;
-	self.results = {};
+class CompositeResult {
+	constructor(key) {
+		this.key = key;
+		this.success = false;
+		this.failure = false;
+		this.failures = 0;
+		this.results = {};
+	}
 
 	/**
 	 * Add a sub-result.
 	 */
-	self.add = function(result)
-	{
-		self.results[result.key] = result;
-		if (result.success && !self.failure)
+	add(result) {
+		this.results[result.key] = result;
+		if (result.success && !this.failure)
 		{
-			self.success = true;
+			this.success = true;
 		}
 		if (result.failure)
 		{
-			self.success = false;
-			self.failure = true;
+			this.success = false;
+			this.failure = true;
 		}
-	};
+	}
 
 	/**
 	 * Return a printable representation.
 	 */
-	self.toString = function(indent)
-	{
+	toString(indent) {
 		indent = indent || 0;
-		var message = getPrintable(self, self.key + SEPARATOR, indent) + '\n';
+		let message = getPrintable(this, this.key + SEPARATOR, indent) + '\n';
 		message += getIndented(indent) + '{\n';
-		for (var key in self.results)
+		for (const key in this.results)
 		{
-			var result = self.results[key];
+			const result = this.results[key];
 			message += result.toString(indent + 1) + ',\n';
 		}
 		message += getIndented(indent) + '}';
 		return message;
-	};
+	}
 
 	/**
 	 * Return a shortened representation.
 	 */
-	self.getSummary = function()
-	{
-		return getPrintable(self, self.key, 0);
-	};
-};
+	getSummary() {
+		return getPrintable(this, this.key, 0);
+	}
+}
 
 /**
  * Get the printable representation for a result, like this:
@@ -172,7 +158,7 @@ var CompositeResult = function(key)
  */
 function getPrintable(result, message, indent)
 {
-	var start;
+	let start;
 	if (!result.failure && !result.success)
 	{
 		start = UNKNOWN_START;
@@ -197,10 +183,10 @@ function getPrintable(result, message, indent)
  */
 function getIndented(indent)
 {
-	var indented = '';
+	let indented = '';
 	if (indent)
 	{
-		for (var i = 0; i < indent; i++)
+		for (let i = 0; i < indent; i++)
 		{
 			indented += '\t';
 		}
@@ -215,10 +201,10 @@ function getIndented(indent)
  */
 exports.run = function(param, callback)
 {
-	var series = clone(param);
+	const series = clone(param);
 	// uncaught exceptions
 	process.on('uncaughtException', uncaughtException);
-	var runner = new Runner('main', series);
+	const runner = new Runner('main', series);
 	runner.runAll(function(error, result)
 	{
 		process.removeListener('uncaughtException', uncaughtException);
@@ -246,78 +232,73 @@ function uncaughtException(error)
 /**
  * A runner for a series of tests.
  */
-var Runner = function(name, series)
-{
-	// self-reference
-	var self = this;
-
-	// attributes
-	self.result = new CompositeResult(name);
-	var finished = false;
+class Runner {
+	constructor(name, series) {
+		this.name = name
+		this.series = series
+		this.result = new CompositeResult(name);
+		this.finished = false;
+	}
 
 	/**
 	 * Run all functions in the series, one by one.
 	 */
-	self.runAll = function(callback)
-	{
-		runOne(function(error, result)
-		{
+	runAll(callback) {
+		this.runOne((error, result) => {
 			if (error)
 			{
-				console.error('Error in test %s: %s', name, error);
+				console.error('Error in test %s: %s', this.name, error);
 			}
 			if (result)
 			{
-				console.log('Finished test %s: %s', name, result.getSummary());
+				console.log('Finished test %s: %s', this.name, result.getSummary());
 			}
-			if (finished)
+			if (this.finished)
 			{
 				return;
 			}
-			finished = true;
+			this.finished = true;
 			callback(error, result);
-		});
-	};
+		})
+	}
 
 	/**
 	 * Run one function in the given series, go to the next.
 	 */
-	function runOne(callback)
-	{
-		if (isEmpty(series))
+	runOne(callback) {
+		if (isEmpty(this.series))
 		{
-			return callback(null, self.result);
+			return callback(null, this.result);
 		}
-		for (var key in series)
+		for (const key in this.series)
 		{
-			var value = series[key];
+			const value = this.series[key];
 			if (!value)
 			{
 				return callback('Empty test for ' + key);
 			}
 			else if (typeof value == 'object')
 			{
-				var runner = new Runner(key, value);
-				return runner.runAll(function(error)
-				{
+				const runner = new Runner(key, value);
+				return runner.runAll(error => {
 					if (error)
 					{
 						console.error('Could not run all functions');
 						return;
 					}
-					self.result.add(runner.result);
-					deleteAndRunNext(key, callback);
+					this.result.add(runner.result);
+					this.deleteAndRunNext(key, callback);
 				});
 			}
 			else if (typeof value == 'function')
 			{
-				var testName = key;
+				let testName = key;
 				if (isNumber(key) && value.name)
 				{
 					testName = value.name;
 				}
 				// it is a function to run
-				next = getNext(key, testName, callback);
+				next = this.getNext(key, testName, callback);
 				if (value.length == 0) {
 					return value().then(result => next(null, result)).catch(error => next(error))
 
@@ -328,19 +309,19 @@ var Runner = function(name, series)
 			else if (typeof value == 'string')
 			{
 				// it is a file name, with a test function
-				var testFunction = getFileTest(value);
+				const testFunction = this.getFileTest(value);
 				if (!testFunction)
 				{
 					console.error('Cannot get test function from file %s', value);
-					return deleteAndRunNext(key, callback);
+					return this.deleteAndRunNext(key, callback);
 				}
-				next = getNext(key, value, callback);
+				next = this.getNext(key, value, callback);
 				return testFunction(next);
 			}
 			else
 			{
 				console.error('Key %s has an invalid value %s', key, value);
-				return deleteAndRunNext(key, callback);
+				return this.deleteAndRunNext(key, callback);
 			}
 			// only the first element in the series is used;
 			// the rest are called by recursion in deleteAndRunNext()
@@ -350,11 +331,10 @@ var Runner = function(name, series)
 	/**
 	 * Get the test function in a file.
 	 */
-	function getFileTest(filename)
-	{
+	getFileTest(filename) {
 		try
 		{
-			var file = require(filename);
+			const file = require(filename);
 			return file.test;
 		}
 		catch(exception)
@@ -366,47 +346,43 @@ var Runner = function(name, series)
 	/**
 	 * Get a function to call after a test.
 	 */
-	function getNext(key, name, callback)
-	{
-		var testResult = new TestResult(name);
-		return function(error, result)
-		{
+	getNext(key, name, callback) {
+		const testResult = new TestResult(name);
+		return (error, result) => {
 			testResult.callback(error, result);
-			self.result.add(testResult);
-			deleteAndRunNext(key, callback);
-		};
+			this.result.add(testResult);
+			this.deleteAndRunNext(key, callback);
+		}
 	}
 
 	/**
 	 * Delete the current function, run the next.
 	 */
-	function deleteAndRunNext(key, callback)
-	{
-		if (!(key in series))
+	deleteAndRunNext(key, callback) {
+		if (!(key in this.series))
 		{
 			// already run
 			return;
 		}
-		delete series[key];
-		var defer = process.nextTick;
+		delete this.series[key];
+		let defer = process.nextTick;
 		if (typeof setImmediate != 'undefined')
 		{
 			// node v0.10.x
 			defer = setImmediate;
 		}
-		return defer(function()
-		{
-			runOne(callback);
-		});
+		return defer(() => {
+			this.runOne(callback);
+		})
 	}
-};
+}
 
 /**
  * Test to run some functions.
  */
 function testRun()
 {
-	var series = {
+	const series = {
 		a: function(callback) {
 			callback(null, 'a');
 		},
@@ -464,10 +440,10 @@ function clone(series)
 		console.error('Invalid series %s', JSON.stringify(series));
 		return;
 	}
-	var copy = {};
-	for (var key in series)
+	const copy = {};
+	for (const key in series)
 	{
-		var value = series[key];
+		const value = series[key];
 		if (typeof value == 'function' || typeof value == 'string')
 		{
 			copy[key] = value;
@@ -485,13 +461,13 @@ function clone(series)
  */
 function testClone()
 {
-	var original = {
+	const original = {
 		a: function() {},
 		b: {
 			c: function() {},
 		},
 	};
-	var cloned = clone(original);
+	const cloned = clone(original);
 	console.assert(cloned.a, 'Cloned object should have function property');
 	console.assert(typeof cloned.a == 'function', 'Cloned object should have function');
 	console.assert(cloned.b, 'Cloned object should have object property');
@@ -505,7 +481,7 @@ function testClone()
  */
 function isEmpty(object)
 {
-	for (var key in object)
+	for (const key in object)
 	{
 		if (object[key])
 		{

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Testing library: runner for tests.
  * (C) 2013 Alex Fernández.
@@ -199,8 +197,7 @@ function getIndented(indent)
  *	- param: an indexed object with functions, or with nested indexed objects.
  *	- callback: a function(error, result) to pass an indexed object with the results.
  */
-exports.run = function(param, callback)
-{
+export function runAll(param, callback) {
 	const series = clone(param);
 	// uncaught exceptions
 	process.on('uncaughtException', uncaughtException);
@@ -215,7 +212,7 @@ exports.run = function(param, callback)
 		}
 		callback(error, result);
 	});
-};
+}
 
 /**
  * Process an uncaught exception.
@@ -404,7 +401,7 @@ function testRun()
 		}],
 		h: ['../index.js', 'shouldNotFindThis.js'],
 	};
-	exports.run(series, function(error, result)
+	run(series, function(error, result)
 	{
 		console.assert(result.failure, 'Root should be failure');
 		console.assert(result.results.a, 'Should have result for a');
@@ -509,22 +506,5 @@ function testEmpty()
 function isNumber(n)
 {
 	return !isNaN(parseFloat(n)) && isFinite(n);
-}
-
-/**
- * Run all module tests.
- * Cannot use testing since it is not defined yet.
- */
-function test()
-{
-	testEmpty();
-	testClone();
-	testRun();
-}
-
-// run tests if invoked directly
-if (__filename == process.argv[1])
-{
-	test();
 }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "3.0.0",
 	"description": "Simple asynchronous testing framework. Never again count your asserts! This tiny testing library is fully callback-based and has a rich API for asserts.",
 	"homepage": "https://github.com/alexfernandez/testing",
+	"type": "module",
 	"contributors": [
 		"Alex Fernández <alexfernandeznpm@gmail.com>"
 	],
@@ -23,7 +24,7 @@
 		"node": ">16"
 	},
 	"scripts": {
-		"test": "node index.js"
+		"test": "node test.js"
 	},
 	"private": false,
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"asynchronous"
 	],
 	"engines": {
-		"node": ">10"
+		"node": ">16"
 	},
 	"scripts": {
 		"test": "node index.js"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
 		"type": "git",
 		"url": "https://github.com/alexfernandez/testing"
 	},
-	"dependencies": {
-		"log": "1.4.0"
-	},
 	"keywords": [
 		"testing",
 		"test",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
 	"scripts": {
 		"test": "node index.js"
 	},
-	"private": false
+	"private": false,
+	"devDependencies": {
+		"eslint": "^8.47.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "testing",
-	"version": "2.0.1",
+	"version": "3.0.0",
 	"description": "Simple asynchronous testing framework. Never again count your asserts! This tiny testing library is fully callback-based and has a rich API for asserts.",
 	"homepage": "https://github.com/alexfernandez/testing",
 	"contributors": [
@@ -20,7 +20,7 @@
 		"asynchronous"
 	],
 	"engines": {
-		"node": ">8"
+		"node": ">10"
 	},
 	"scripts": {
 		"test": "node index.js"

--- a/test.js
+++ b/test.js
@@ -1,0 +1,11 @@
+/**
+ * Testing library.
+ * (C) 2013 Alex Fernández.
+ */
+
+
+import {test, show} from './index.js'
+
+
+test(show);
+


### PR DESCRIPTION
Version 3.0.0. Changes:

* Add `eslint` configuration.
* Remove `log` library, use `console`.
* Use `Object.hasOwn()`.
* Modernize code: do not use `var`, use `class`.
* Convert to ES6 module.

Requires Node.js >= 16. For immediate merge.