### PR TITLE
Export library as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Versions 2 should be used at least with Node.js v8 or later.
 
 ## Usage
 
-Add asynchronous testing to your code very easily. Require testing:
+Add asynchronous testing to your code very easily. Import the library:
 
 ```js
-var testing = require('testing');
+import testing from 'testing';
 ```
 
 ### Unit tests

--- a/README.md
+++ b/README.md
@@ -288,13 +288,13 @@ Runs a couple of tests in parallel, showing their results as they finish.
 ### Sample code
 
 This library is tested using itself, check it out!
-  https://github.com/alexfernandez/testing/blob/master/index.js
+  https://github.com/alexfernandez/testing/blob/master/test.js
 
 ## License
 
 (The MIT License)
 
-Copyright (c) 2013 Alex Fernández <alexfernandeznpm@gmail.com>
+Copyright (c) 2013-2023 Alex Fernández <alexfernandeznpm@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -66,53 +66,44 @@ Or, with callbacks:
 
 ### Running all tests
 
-Run all tests:
-```js
-    testing.run([
-        testAdd,
-        testAsync,
-    ], callback);
-```
-Will run tests sequentially. Usually test are run inside an exported function `test`:
-```js
-    /**
-     * Run package tests.
-     */
-    exports.test = function(callback)
-    {   
-        var tests = [
-            testAdd,
-            testAsync,
-        ];
-        testing.run(tests, callback);
-    };  
-        
-    // run tests if invoked directly
-    if (__filename == process.argv[1])
-    {   
-        exports.test(testing.show);
-    }
-```
-All tests are run every time the file is invoked directly:
-```js
-    node my-file.js
-```
-The function `test` is exported so that tests from all source code files
-can be required and run in sequence from a master file,
-usually called `test.js` and placed in the root of the project.
+Pass an array to `testing.run()` to run all tests sequentially:
 
-### Running all tests in a project
-
-If you want to run all tests in a project, you can pass a filename as a test:
 ```js
-    var tests = [
-        __dirname__ + '/lib/first.js',
-        __dirname__ + '/lib/second.js',
-    ];
-    testing.run(tests, callback);
+testing.run([
+	testAdd,
+	testAsync,
+], callback);
 ```
-Each file should have its own exported test function.
-This is a common practice in a global test file `test.js`.
+
+Usually tests are stored in a separate file.
+Each test file will export its tests as a function,
+e.g. `testAdd()`.
+An aggregate file will run all package tests directly:
+
+```js
+import testing from 'testing'
+import testAdd from './testAdd.js'
+import testAsync from './testAsync.js'
+
+/**
+ * Run package tests.
+ */
+function test(callback) {
+	var tests = [
+		testAdd,
+		testAsync,
+	];
+	testing.run(tests, callback);
+};
+	
+test(testing.show);
+```
+
+Tests are run every time this aggregate file is invoked directly:
+
+```js
+ $ node test/all.js
+```
 
 ## API
 

--- a/index.js
+++ b/index.js
@@ -62,6 +62,10 @@ export function fail(...args) {
 	return failure(...args)
 }
 
+export function removeError() {
+	errors -= 1
+}
+
 /**
  * Find a callback in any parameter, extract the message. Parameters:
  * - args: an array like, will be sanitized before util.format() is used to get the message.
@@ -88,18 +92,6 @@ function processParameters(args)
 	}
 	parameters.message = util.format.apply(util, reargs);
 	return parameters;
-}
-
-/**
- * Test success and failure.
- */
-function testSuccessFailure(callback)
-{
-	success('success');
-	failure('test; please ignore');
-	// remove this error
-	errors -= 1;
-	success('Success and failure work', callback);
 }
 
 /**
@@ -226,20 +218,6 @@ export function check(error, message, callback) {
 }
 
 /**
- * Test assert functions.
- */
-function testAssert(callback)
-{
-	verify(1 + 1 == 2, 'Basic assert', callback);
-	equals(1 + 1, 2, 'Basic assert equals', callback);
-	equals({a: 'a'}, {a: 'a'}, 'Object assert equals', callback);
-	notEquals(1 + 1, 3, 'Basic assert not equals', callback);
-	notEquals({a: 'a'}, {a: 'b'}, 'Object assert not equals', callback);
-	check(false, 'Check should not trigger', callback);
-	success(callback);
-}
-
-/**
  * Run a set of tests. Parameters:
  *	- tests: an object with an attribute for every test function,
 *	an array or a single function.
@@ -315,7 +293,7 @@ function showResults(error, result)
 {
 	if (error)
 	{
-		exports.failure(error);
+		failure(error);
 		process.exit(1);
 		return;
 	}
@@ -336,27 +314,6 @@ function showResults(error, result)
 }
 
 /**
- * A test which returns a complex object, to check how results are displayed.
- */
-function testObject(callback)
-{
-	const object = {
-		embedded: {
-			key: 'value',
-		},
-	};
-	success(object, callback);
-}
-
-/**
- * Function to test separately.
- */
-function testSingleFunction(callback)
-{
-	success(true, callback);
-}
-
-/**
  * Pass a tester callback whose results you want shown.
  * Returns a function that runs the tests, shows the results and invokes the callback.
  */
@@ -371,42 +328,6 @@ export function toShow(tester) {
 	};
 }
 
-async function testPromise()
-{
-	await sleep(100)
-	return 'promise'
-}
-
-function sleep(ms) {
-	return new Promise(resolve => {
-		setTimeout(() => {
-			resolve()
-		}, ms)
-	})
-}
-
-/**
- * Run all module tests.
- */
-export function test(callback) {
-	const tests = [
-		testSuccessFailure,
-		testAssert,
-		{
-			recursive: {
-				object: testObject,
-			},
-		},
-		testPromise,
-	];
-	run(testSingleFunction, function(error, result)
-	{
-		check(error, 'Could not run single function', callback);
-		assert(result, 'Invalid test result', callback);
-		run(tests, callback);
-	});
-}
-
 function error(message) {
 	console.error(RED + message + BLACK);
 }
@@ -414,4 +335,12 @@ function error(message) {
 function notice(message) {
 	console.log(GREEN + message + BLACK);
 }
+
+const testing = {
+	success, failure, fail, removeError, verify, assert,
+	equals, assertEquals, notEquals, assertNotEquals,
+	contains, check, run, show, showComplete, toShow,
+}
+
+export default testing
 

--- a/index.js
+++ b/index.js
@@ -117,8 +117,9 @@ export function verify(condition, message, callback) {
 	// show failure with the given arguments
 	failure(message, callback);
 }
-export function assert(condition, message, callback) {
-	return verify(condition, message, callback)
+
+export function assert(...args) {
+	return verify(...args)
 }
 
 /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -348,63 +348,9 @@ class Runner {
 }
 
 /**
- * Test to run some functions.
- */
-function testRun()
-{
-	const series = {
-		a: function(callback) {
-			callback(null, 'a');
-		},
-		b: {
-			e: function(callback) {
-				callback('e');
-			},
-			c: function(callback) {
-				callback(null, 'c');
-			},
-			f: function() {
-				throw new Error('exception');
-			},
-		},
-		g: [function(callback) {
-			callback(null, 'g0');
-		}, function two(callback) {
-			callback(null, 'g1');
-		}],
-		h: ['../index.js', 'shouldNotFindThis.js'],
-	};
-	run(series, function(error, result)
-	{
-		console.assert(result.failure, 'Root should be failure');
-		console.assert(result.results.a, 'Should have result for a');
-		console.assert(result.results.a.success, 'Should have success for a');
-		console.assert(result.results.a.message == 'a', 'Should have an a for a');
-		console.assert(result.results.b, 'Should have result for b');
-		console.assert(result.results.b.failure, 'Should have failure for b');
-		console.assert(result.results.b.results.c, 'Should have result for b.c');
-		console.assert(result.results.b.results.c.success, 'Should have success for b.c');
-		console.assert(result.results.b.results.c.message == 'c', 'Should have a c for b.c');
-		console.assert(result.results.b.results.e, 'Should have result for b.e');
-		console.assert(result.results.b.results.e.failure, 'Should have failure for b.e');
-		console.assert(result.results.b.results.e.message == 'e', 'Should have a e for b.e');
-		console.assert(result.results.g, 'Should have result for g');
-		console.assert(result.results.g.success, 'Should have success for g');
-		console.assert(result.results.g.results[0], 'Should have result for g[0]');
-		console.assert(result.results.g.results[0].success, 'Should have success for g[0]');
-		console.assert(result.results.g.results[0].message == 'g0', 'Should have g0 for g[0]');
-		console.assert(result.results.g.results.two, 'Should have result for two');
-		console.assert(result.results.g.results.two.success, 'Should have success for two');
-		console.assert(result.results.g.results.two.message == 'g1', 'Should have g1 for two');
-		console.log('Test run successful with 2 failures: %s', result);
-	});
-}
-
-/**
  * Clone a series of functions. Performs a sanity check.
  */
-function clone(series)
-{
+export function clone(series) {
 	if (typeof series != 'object')
 	{
 		console.error('Invalid series %s', JSON.stringify(series));
@@ -427,30 +373,9 @@ function clone(series)
 }
 
 /**
- * Test the clone function.
- */
-function testClone()
-{
-	const original = {
-		a: function() {},
-		b: {
-			c: function() {},
-		},
-	};
-	const cloned = clone(original);
-	console.assert(cloned.a, 'Cloned object should have function property');
-	console.assert(typeof cloned.a == 'function', 'Cloned object should have function');
-	console.assert(cloned.b, 'Cloned object should have object property');
-	console.assert(typeof cloned.b == 'object', 'Cloned object should have object');
-	console.assert(cloned.b.c, 'Cloned object should have sub-object property');
-	console.assert(typeof cloned.b.c == 'function', 'Cloned object should have sub-object');
-}
-
-/**
  * Find out if the object is empty.
  */
-function isEmpty(object)
-{
+export function isEmpty(object) {
 	for (const key in object)
 	{
 		if (object[key])
@@ -459,17 +384,6 @@ function isEmpty(object)
 		}
 	}
 	return true;
-}
-
-/**
- * Test the empty function.
- */
-function testEmpty()
-{
-	console.assert(isEmpty({}), 'Empty object should be empty');
-	console.assert(!isEmpty({a: 'a'}), 'Not empty object is empty');
-	console.assert(isEmpty([]), 'Empty array should be empty');
-	console.assert(!isEmpty(['a']), 'Not empty array is empty');
 }
 
 /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -303,18 +303,6 @@ class Runner {
 					return value(next);
 				}
 			}
-			else if (typeof value == 'string')
-			{
-				// it is a file name, with a test function
-				const testFunction = this.getFileTest(value);
-				if (!testFunction)
-				{
-					console.error('Cannot get test function from file %s', value);
-					return this.deleteAndRunNext(key, callback);
-				}
-				next = this.getNext(key, value, callback);
-				return testFunction(next);
-			}
 			else
 			{
 				console.error('Key %s has an invalid value %s', key, value);
@@ -322,21 +310,6 @@ class Runner {
 			}
 			// only the first element in the series is used;
 			// the rest are called by recursion in deleteAndRunNext()
-		}
-	}
-
-	/**
-	 * Get the test function in a file.
-	 */
-	getFileTest(filename) {
-		try
-		{
-			const file = require(filename);
-			return file.test;
-		}
-		catch(exception)
-		{
-			console.error('File %s not found: %s', filename, exception);
 		}
 	}
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,0 +1,105 @@
+/**
+ * Testing library: runner for tests.
+ * (C) 2013 Alex Fernández.
+ */
+
+import {runAll, clone, isEmpty} from './runner.js'
+
+/**
+ * Test to run some functions.
+ */
+function testRun()
+{
+	const successes = {
+		a: function(callback) {
+			callback(null, 'a');
+		},
+		b: [function(callback) {
+			callback(null, 'b0');
+		}, function two(callback) {
+			callback(null, 'b1');
+		}],
+	};
+	runAll(successes, function(error, result) {
+		console.assert(result.success, 'Root should be success');
+		console.assert(result.results.a, 'Should have result for a');
+		console.assert(result.results.a.success, 'Should have success for a');
+		console.assert(result.results.a.message == 'a', 'Should have an a for a');
+		console.assert(result.results.b, 'Should have result for b');
+		console.assert(result.results.b.success, 'Should have success for b');
+		console.assert(result.results.b.results[0], 'Should have result for b[0]');
+		console.assert(result.results.b.results[0].success, 'Should have success for b[0]');
+		console.assert(result.results.b.results[0].message == 'b0', 'Should have b0 for b[0]');
+		console.assert(result.results.b.results.two, 'Should have result for two');
+		console.assert(result.results.b.results.two.success, 'Should have success for two');
+		console.assert(result.results.b.results.two.message == 'b1', 'Should have b1 for two');
+		console.log('Test run successfully without failures: %s', result);
+	});
+	const failures = {
+		c: {
+			d: function(callback) {
+				callback('d');
+			},
+			e: function(callback) {
+				callback(null, 'e');
+			},
+			f: function() {
+				throw new Error('exception');
+			},
+		},
+	}
+	runAll(failures, function(error) {
+		console.log(error)
+		console.assert(error.failure, 'Root should be failure');
+		console.assert(error.results.c, 'Should have result for b');
+		console.assert(error.results.c.failure, 'Should have failure for c');
+		console.assert(error.results.c.results.d, 'Should have result for c.d');
+		console.assert(error.results.c.results.d.message == 'd', 'Should have a d for c.d');
+		console.assert(error.results.c.results.e, 'Should have result for c.e');
+		console.assert(error.results.c.results.e.success, 'Should have success for c.e');
+		console.assert(error.results.c.results.e.message == 'e', 'Should have an e for c.e');
+		console.assert(error.results.c.results.f, 'Should have result for c.f');
+		console.assert(error.results.c.results.f.failure, 'Should have failure for b.e');
+		console.log('Test run successful with 2 failures: %s', error);
+	})
+}
+
+/**
+ * Test the clone function.
+ */
+function testClone()
+{
+	const original = {
+		a: function() {},
+		b: {
+			c: function() {},
+		},
+	};
+	const cloned = clone(original);
+	console.assert(cloned.a, 'Cloned object should have function property');
+	console.assert(typeof cloned.a == 'function', 'Cloned object should have function');
+	console.assert(cloned.b, 'Cloned object should have object property');
+	console.assert(typeof cloned.b == 'object', 'Cloned object should have object');
+	console.assert(cloned.b.c, 'Cloned object should have sub-object property');
+	console.assert(typeof cloned.b.c == 'function', 'Cloned object should have sub-object');
+}
+
+/**
+ * Test the empty function.
+ */
+function testEmpty()
+{
+	console.assert(isEmpty({}), 'Empty object should be empty');
+	console.assert(!isEmpty({a: 'a'}), 'Not empty object is empty');
+	console.assert(isEmpty([]), 'Empty array should be empty');
+	console.assert(!isEmpty(['a']), 'Not empty array is empty');
+}
+
+function testAll() {
+	testRun()
+	testClone()
+	testEmpty()
+}
+
+testAll()
+

--- a/test.js
+++ b/test.js
@@ -4,8 +4,90 @@
  */
 
 
-import {test, show} from './index.js'
+import testing from './index.js'
 
 
-test(show);
+/**
+ * Test success and failure.
+ */
+function testSuccessFailure(callback)
+{
+	testing.success('success');
+	testing.failure('test; please ignore');
+	testing.removeError()
+	testing.success('Success and failure work', callback);
+}
+
+/**
+ * Test assert functions.
+ */
+function testAssert(callback)
+{
+	testing.verify(1 + 1 == 2, 'Basic assert', callback);
+	testing.equals(1 + 1, 2, 'Basic assert equals', callback);
+	testing.equals({a: 'a'}, {a: 'a'}, 'Object assert equals', callback);
+	testing.notEquals(1 + 1, 3, 'Basic assert not equals', callback);
+	testing.notEquals({a: 'a'}, {a: 'b'}, 'Object assert not equals', callback);
+	testing.check(false, 'Check should not trigger', callback);
+	testing.success(callback);
+}
+
+/**
+ * A test which returns a complex object, to check how results are displayed.
+ */
+function testObject(callback)
+{
+	const object = {
+		embedded: {
+			key: 'value',
+		},
+	};
+	testing.success(object, callback);
+}
+
+function sleep(ms) {
+	return new Promise(resolve => {
+		setTimeout(() => {
+			resolve()
+		}, ms)
+	})
+}
+
+async function testPromise()
+{
+	await sleep(100)
+	return 'promise'
+}
+
+/**
+ * Function to test separately.
+ */
+function testSingleFunction(callback)
+{
+	testing.success(true, callback);
+}
+
+/**
+ * Run all module tests.
+ */
+function testAll(callback) {
+	const tests = [
+		testSuccessFailure,
+		testAssert,
+		{
+			recursive: {
+				object: testObject,
+			},
+		},
+		testPromise,
+	];
+	testing.run(testSingleFunction, function(error, result)
+	{
+		testing.check(error, 'Could not run single function', callback);
+		testing.assert(result, 'Invalid test result', callback);
+		testing.run(tests, callback);
+	});
+}
+
+testAll(testing.show);
 


### PR DESCRIPTION
Library is now exported as `default` so users can `import testing from 'testing'`.

Also in this PR:

* Document `import` and default import instead of `require()`.
* Separate tests and code.
* Document modern separation of tests and code.

For immediate merge.